### PR TITLE
make scm-go work with current config format

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,9 +10,14 @@ import (
 
 //This marshals the json config file into a useful type structure to use throughout the application
 
+type Stream struct {
+	Level  string `json:"level"`
+	Stream string `json:"stream"`
+}
+
 type Logger struct {
-	Level    string `json:"level"`
-	Filename string `json:"filename"`
+	Name    string
+	Streams []Stream `json:"streams"`
 }
 
 type Connect struct {
@@ -46,7 +51,7 @@ type Config struct {
 	Ssl           SSL           `json:"ssl"`
 	Fileserver    FileServer    `json:"fileserver"`
 	Millicore     Millicore     `json:"millicore"`
-	Logger        []Logger      `json:"logger"`
+	Logger        Logger        `json:"logger"`
 }
 
 func (c Config) GetRepoPath(repoName string) string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,6 +21,14 @@ func Test_Marshal_Config(t *testing.T) {
 			"privateKey":"",
 			"publicCert":""
 		},
+		"logger": {
+			"name": "scm",
+			"streams": [{
+
+				"stream": "process.stdout",
+				"level": "debug"
+			}]
+		},
 		"fileserver": {
     		"path": "/tmp/fh-scm",
     		"backup": "/tmp/fh-scm/backup"
@@ -50,6 +58,6 @@ func Test_NewConfig(t *testing.T) {
 	}
 	assert.Equal(t, "/tmp/fh-scm/test", conf.GetRepoPath("test"), "expected repo name to be correct")
 	assert.Equal(t, 8801, conf.Githubtrigger.Port, " port should be 8801")
-	assert.Equal(t, "debug", conf.Logger[0].Level, " level should debug")
+	assert.Equal(t, "debug", conf.Logger.Streams[0].Level, " level should debug")
 
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -15,23 +15,13 @@
     "path": "/tmp/fh-scm/",
     "backup": "/tmp/fh-scm/backup"
   },
-
-  "logger": [
-    {
-      "type": "winston.transports.File",
-      "filename": "/tmp/fh-scm.log",
-      "json": false,
-      "level": "debug",
-      "handleExceptions": true
-    },
-    {
-      "type": "winston.transports.Console",
-      "json": false,
-      "level": "debug",
-      "colorize": true
-    }
-  ],
-
+  "logger": {
+    "name": "scm",
+    "streams": [{
+      "stream": "fh-scm.log",
+      "level": "debug"
+    }]
+  },
   "gitcommands": {
     "get":        "git clone --branch 'BRANCH_NAME' 'REPO_URL' .",
     "update":     "git pull && git pull --tags",

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -5,20 +5,43 @@ import (
 
 	"github.com/maleck13/scm-go/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/maleck13/scm-go/Godeps/_workspace/src/github.com/fheng/scm-go/config"
+	"io"
 )
 
-//TODO write to file and stdout
-
 var Logger = logrus.New()
+var logFilePath = "/var/log/feedhenry/fh-scm/"
 
-func InitLogger(loggers []config.Logger) *logrus.Logger {
-	logger := loggers[0]
+func directoryExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+
+	return false, err
+}
+
+func InitLogger(loggers config.Logger) *logrus.Logger {
+	logger := loggers.Streams[0]
 	Logger.Formatter = new(logrus.JSONFormatter)
-	f, err := os.OpenFile(logger.Filename, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+
+	// Check if we can use the standard log directory. If not
+	// fall back to tmp
+	if result, _ := directoryExists(logFilePath); !result {
+		logFilePath = "/tmp/"
+	}
+
+	// Use the 'Stream' value from the fh-scm config as the filename
+	// for now
+	logFileName := logFilePath + logger.Stream
+
+	f, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
 		Logger.Fatal(err)
 	}
-	Logger.Out = f
+
+	// Log to file and stdout
+	Logger.Out = io.MultiWriter(f, os.Stdout)
+
 	switch logger.Level {
 	case "info":
 		Logger.Level = logrus.InfoLevel


### PR DESCRIPTION
# Motivation

The fh-scm config file is also used by scm-go. The config file has changed and this PR brings scm-go up-to-date (or at least makes it work) with the current format. Also directs all log output to file and stdout.

With this fix i can actually run scm-go as a replacement for fh-scm and i would like to port over the new features that have been introduced into fh-scm since (keystore and symlink-checking).

ping @maleck13  